### PR TITLE
update charset meta tag to HTML5

### DIFF
--- a/contact-form/index.php
+++ b/contact-form/index.php
@@ -39,7 +39,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         <!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Transitional//EN\" \"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd\">
         <html>
             <head>
-                <meta http-equiv=\"Content-Type\" content=\"text/html; charset=utf-8\" />
+                <meta charset=\"utf-8\">
             </head>
             <body>
                 <h1>{$subject}</h1>
@@ -63,7 +63,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <head>
     <title>Simple PHP Contact Form</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta charset="utf-8">
     <link href="//netdna.bootstrapcdn.com/bootstrap/3.3.6/css/bootstrap.min.css" rel="stylesheet" media="screen">
 </head>
 <body>


### PR DESCRIPTION
hello,

Thank you for sharing your contact form! It has proven to be very useful!

While integrating it in one of my projects, I noticed the charset meta tag is still using the HTML4 standard. In HTML5 this is [an 'obsolete API'](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta#attr-http-equiv), so this pull request replaces it with the HTML5 equivalent of it.