### PR TITLE
Containerized version. Adds ssmtp to setup mail.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,52 @@
+FROM alpine:3.6
+
+LABEL description "Containerized Simple PHP Contact Form" \
+      maintainer="Kayvan Sylvan <kayvansylvan@gmail.com>"
+
+ENV UID=991 GID=991
+
+RUN echo "@community https://nl.alpinelinux.org/alpine/v3.6/community" >> /etc/apk/repositories \
+ && apk -U upgrade \
+ && apk add -t build-dependencies \
+    gnupg \
+    openssl \
+    wget \
+ && apk add \
+    ca-certificates \
+    nginx \
+    ssmtp \
+    s6 \
+    su-exec \
+    php7-fpm@community \
+    php7-curl@community \
+    php7-iconv@community \
+    php7-xml@community \
+    php7-dom@community \
+    php7-openssl@community \
+    php7-json@community \
+    php7-zlib@community \
+    php7-pdo_mysql@community \
+    php7-pdo_sqlite@community \
+    php7-sqlite3@community \
+    php7-ldap@community \
+    php7-simplexml@community \
+ && cd /tmp \
+ && apk del build-dependencies \
+ && rm -rf /tmp/* /var/cache/apk/* /root/.gnupg \
+ && echo 'webform:x:991:991:Web Form:/tmp:/sbin/nologin' >> /etc/passwd
+# The passwd hack above is for ssmtpd to function
+
+COPY nginx.conf /etc/nginx/nginx.conf
+COPY php-fpm.conf /etc/php7/php-fpm.conf
+COPY s6.d /etc/s6.d
+COPY run.sh /usr/local/bin/run.sh
+COPY contact-form /contact
+
+RUN chmod +x /usr/local/bin/run.sh /etc/s6.d/*/* /etc/s6.d/.s6-svscan/*
+
+VOLUME /contact/config
+VOLUME /etc/ssmtp
+
+EXPOSE 8888
+
+CMD ["run.sh"]

--- a/README.md
+++ b/README.md
@@ -2,6 +2,13 @@
 
 A Simple Contact Form developed in PHP with HTML5 Form validation. Has a fallback in JavaScript for browsers that do not support HTML5 form validation.
 
+## Containerized with Alpine based container
+
+Using techniques from https://github.com/hardware/rainloop
+
+The container adds ssmtp so you can set up a working config in /etc/ssmtp/
+for the outgoing mail.
+
 ## Demo
 
 View [demo here](http://www.pinceladasdaweb.com.br/blog/uploads/contact-form/).

--- a/nginx.conf
+++ b/nginx.conf
@@ -1,0 +1,78 @@
+worker_processes auto;
+pid /tmp/nginx.pid;
+daemon off;
+
+events {
+  worker_connections 1024;
+  use epoll;
+}
+
+http {
+  include /etc/nginx/mime.types;
+  default_type  application/octet-stream;
+
+  access_log off;
+  error_log /tmp/ngx_error.log error;
+
+  sendfile on;
+  keepalive_timeout 15;
+  keepalive_disable msie6;
+  keepalive_requests 100;
+  tcp_nopush on;
+  tcp_nodelay on;
+  server_tokens off;
+
+  fastcgi_temp_path /tmp/fastcgi 1 2;
+  client_body_temp_path /tmp/client_body 1 2;
+  proxy_temp_path /tmp/proxy 1 2;
+  uwsgi_temp_path /tmp/uwsgi 1 2;
+  scgi_temp_path /tmp/scgi 1 2;
+
+  gzip on;
+  gzip_comp_level 5;
+  gzip_min_length 512;
+  gzip_buffers 4 8k;
+  gzip_proxied any;
+  gzip_vary on;
+  gzip_disable "msie6";
+  gzip_types
+    text/css
+    text/javascript
+    text/xml
+    text/plain
+    text/x-component
+    application/javascript
+    application/x-javascript
+    application/json
+    application/xml
+    application/rss+xml
+    application/vnd.ms-fontobject
+    font/truetype
+    font/opentype
+    image/svg+xml;
+
+  server {
+    listen 8888;
+    root /contact;
+    index index.php;
+    charset utf-8;
+    client_max_body_size 50M;
+
+    location ^~ /data {
+      deny all;
+    }
+
+    location / {
+      try_files $uri $uri/ index.php;
+    }
+
+    location ~* \.php$ {
+      fastcgi_index index.php;
+      fastcgi_pass unix:/tmp/php-fpm.sock;
+      fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+      include /etc/nginx/fastcgi_params;
+    }
+
+  }
+
+}

--- a/php-fpm.conf
+++ b/php-fpm.conf
@@ -1,0 +1,14 @@
+[global]
+daemonize = no
+
+[www]
+listen = /tmp/php-fpm.sock
+pm = dynamic
+pm.max_children = 5
+pm.start_servers = 2
+pm.min_spare_servers = 1
+pm.max_spare_servers = 3
+chdir = /
+php_admin_value[expose_php] = Off
+php_admin_value[post_max_size] = 50M
+php_admin_value[upload_max_filesize] = 50M

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+chown -R $UID:$GID /contact /etc/nginx /etc/php7 /var/log /var/lib/nginx /tmp /etc/s6.d
+exec su-exec $UID:$GID /bin/s6-svscan /etc/s6.d

--- a/s6.d/.s6-svscan/finish
+++ b/s6.d/.s6-svscan/finish
@@ -1,0 +1,2 @@
+#!/bin/sh
+exit 0

--- a/s6.d/nginx/run
+++ b/s6.d/nginx/run
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec nginx

--- a/s6.d/php/run
+++ b/s6.d/php/run
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec php-fpm7


### PR DESCRIPTION
Used this as the basis of a contact form micro-service running as part of a web and mail server stack.

You can run the base image by doing, for example:

```
docker run -p 8888:8888 --rm -it kayvan/contact-form
```

And then visiting localhost:8888 - the mail will not go anywhere till you set up a working ssmtp configuration, but that's pretty simple. 