### PR TITLE
remove sender from mail function

### DIFF
--- a/contact-form/vendor/SimpleMail/SimpleMail.class.php
+++ b/contact-form/vendor/SimpleMail/SimpleMail.class.php
@@ -79,6 +79,6 @@ class SimpleMail
 
         ini_set('sendmail_from', $this->from);
 
-        mail($this->to, '=?UTF-8?B?' . base64_encode($this->subject) . '?=', $message, $header);
+        mail("", '=?UTF-8?B?' . base64_encode($this->subject) . '?=', $message, $header);
     }
 }


### PR DESCRIPTION
There is already set the TO header manually. By setting a receiver in the mail function a second TO header is generated and it shows up twice in mail programs. See #30 